### PR TITLE
Failing specs

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,7 +17,7 @@ require 'monkey_patches'
 require 'fixtures'
 require 'fake_server'
 
-disable_net_connect!
+WebMock.respond_to?(:disable_net_connect!) ? WebMock.disable_net_connect! : disable_net_connect!
 
 Spec::Runner.configure do |config|
   config.mock_with :mocha

--- a/spec/web_app_continue_spec.rb
+++ b/spec/web_app_continue_spec.rb
@@ -4,7 +4,7 @@ require 'ostruct'
 module OauthWrap
   describe WebApp, '#continue' do
     before :each do
-      WebMock.reset_webmock
+      WebMock.respond_to?(:reset!) ? WebMock.reset! : WebMock.reset_webmock
       FakeOauthServer.new.start
       @web_app = OauthWrap.as_web_app(:authorization_url => Fixtures::AUTH_URL).as(*Fixtures::VALID_CREDENTIALS.first)
       @illegal_web_app = OauthWrap.as_web_app(:authorization_url => Fixtures::AUTH_URL).as("hacker", "i-am-1337")

--- a/spec/web_app_refresh_spec.rb
+++ b/spec/web_app_refresh_spec.rb
@@ -4,7 +4,7 @@ require 'ostruct'
 module OauthWrap
   describe WebApp, '#refresh' do
     before :each do
-      WebMock.reset_webmock
+      WebMock.respond_to?(:reset!) ? WebMock.reset! : WebMock.reset_webmock
       FakeOauthServer.new.start
       
       @web_app = OauthWrap.

--- a/spec/web_app_request_spec.rb
+++ b/spec/web_app_request_spec.rb
@@ -4,7 +4,7 @@ require 'ostruct'
 module OauthWrap
   describe WebApp, '#request' do
     before :each do
-      WebMock.reset_webmock
+      WebMock.respond_to?(:reset!) ? WebMock.reset! : WebMock.reset_webmock
       FakeOauthServer.new.start
       
       @web_app = OauthWrap.


### PR DESCRIPTION
Trying to run `rake spec` fails at:
    'OauthWrap::WebApp#refresh when accessing a resource is called if access was denied due to an expired access_token' FAILED
    expected no OauthWrap::Unauthorized, got #<OauthWrap::Unauthorized: OauthWrap::Unauthorized>

Maybe this error is due to a bad `fake_server` implementation.

Also some documentation could be useful.
